### PR TITLE
Update Synchronizer.java

### DIFF
--- a/org.moflon.tgg.language/src/org/moflon/tgg/algorithm/synchronization/Synchronizer.java
+++ b/org.moflon.tgg.language/src/org/moflon/tgg/algorithm/synchronization/Synchronizer.java
@@ -237,7 +237,7 @@ public abstract class Synchronizer {
 	}
 
 	private AttributeConstraintsRuleResult checkCSP(TripleMatch match) {
-		EClass ruleClass = findRule(match.getRuleName()).getIsAppropriateMethods().get(0).getEContainingClass();
+		EClass ruleClass = findRule(match.getRuleName()).getCheckDECMethod().getEContainingClass();
 
 		for (EOperation o : ruleClass.getEAllOperations()) {
 			if (("checkAttributes_" + getDirection()).equals(o.getName())) {


### PR DESCRIPTION
In findRule(match.getRuleName()).getIsAppropriateMethods().get(0).getEContainingClass();
the method .getIsAppropriateMethods() returns empty array when it is used for the ignore rule in
backward direction. 

getCheckDECMethod() instead of .getIsAppropriateMethods() works in both directions.